### PR TITLE
souces files in deb822 format

### DIFF
--- a/share/fll-live-initscripts/fll_locales
+++ b/share/fll-live-initscripts/fll_locales
@@ -575,9 +575,9 @@ localize_sources() {
 	compo="main non-free-firmware"
 	key="/usr/share/keyrings/siduction-archive-keyring.gpg"
 
-	for target_file in "extra.sources" "fixes.sources"; do
-		target="/etc/apt/sources.list.d/$target_file"
-		url="${FLL_MIRROR}"
+	for target_file in "extra" "fixes"; do
+		target="/etc/apt/sources.list.d/${target_file}.sources"
+		url="${FLL_MIRROR}${target_file}"
 		yes_no="yes"
 		
 		cat << EOF > $target
@@ -597,6 +597,7 @@ EOF
 			# Set and use indirection to access array values.
 			choice=$country[@]
 			for url in ${!choice}; do
+				url="${url}/${target_file}"
 				if [ $number -gt 1 ]; then
 					echo "" >> ${target}
 					echo "" >> ${target}

--- a/share/fll-live-initscripts/fll_locales
+++ b/share/fll-live-initscripts/fll_locales
@@ -412,197 +412,200 @@ localize_sources_list() {
 #   4) fixes        - provided directly via packages.siduction.site
 
 	case "$(mawk 'BEGIN{print int(9 * rand())}')" in
-	    0)
-	         # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
-	         FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
-	         ;;
-	    1)
-	         # OfficeVienna EDV-Dienstleistungen und IT-Consulting, Austria
-	         FLL_MIRROR="https://siduction.office-vienna.at/"
-	         ;;
-	    3)
-	         # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
-	         FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
-	         ;;
-	    4)
-	         # University Stuttgart, Germany
-	         FLL_MIRROR="https://ftp.uni-stuttgart.de/siduction/"
-	         ;;
-	    5)
-	         # BelNet, Belgium
-	         FLL_MIRROR="https://ftp.belnet.be/mirror/siduction/"
-	         ;;
-#        6)
-#	         # Studenten Net Twente, Netherlands
-#	         FLL_MIRROR="https://ftp.snt.utwente.nl/pub/linux/siduction/"
-#	         ;;
-        7)
-	         # Consortium GARR, Italy
-	         FLL_MIRROR="https://siduction.mirror.garr.it/"
-	         ;;
-	    *)
-	         # siduction main mirror, with TLS since Sunday, 21/08/2016
-	         FLL_MIRROR="https://packages.siduction.org/"
-	         ;;
+		0)
+		 # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
+		 FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
+		 ;;
+		1)
+		 # OfficeVienna EDV-Dienstleistungen und IT-Consulting, Austria
+		 FLL_MIRROR="https://siduction.office-vienna.at/"
+		 ;;
+		2)
+		 #
+		 ;;
+		3)
+		 # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
+		 FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
+		 ;;
+		4)
+		 # University Stuttgart, Germany
+		 FLL_MIRROR="https://ftp.uni-stuttgart.de/siduction/"
+		 ;;
+		5)
+		 # BelNet, Belgium
+		 FLL_MIRROR="https://ftp.belnet.be/mirror/siduction/"
+		 ;;
+		6)
+		 # Studenten Net Twente, Netherlands
+		 FLL_MIRROR="https://ftp.snt.utwente.nl/pub/linux/siduction/"
+		 ;;
+		7)
+		 # Consortium GARR, Italy
+		 FLL_MIRROR="https://siduction.mirror.garr.it/"
+		 ;;
+		*)
+		 # siduction main mirror, with TLS since Sunday, 21/08/2016
+		 FLL_MIRROR="https://packages.siduction.org/"
+		 ;;
 	esac
 
 	target="/etc/apt/sources.list.d/debian.list"
 	echo "# debian loadbalancer" > ${target}
 	echo "deb      https://deb.debian.org/debian/ unstable main non-free-firmware" >> ${target}
 	echo "#deb-src https://deb.debian.org/debian/ unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
-        echo "# deb-src https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb      https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
-        echo "# deb-src  https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
+	echo "# deb-src https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb      https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
+	echo "# deb-src  https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
 
 	target="/etc/apt/sources.list.d/extra.list"
-        echo "# This is the default mirror, choosen at first boot." > ${target}
-        echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
+	echo "# This is the default mirror, choosen at first boot." > ${target}
+	echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
 	echo "deb      ${FLL_MIRROR}extra unstable main non-free-firmware" >> ${target}
 	echo "#deb-src ${FLL_MIRROR}extra unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-        echo "# Austria" >> ${target}
-        echo "# deb     https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Belgium" >> ${target}
-        echo "# deb     https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Denmark" >> ${target}
-        echo "# deb     https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Ecuador" >> ${target}
-        echo "# deb     https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Germany" >> ${target}
-      	echo "# deb     https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Hong Kong" >> ${target}
-        echo "# deb     https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Hungary" >> ${target}
-        echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Italy" >> ${target}
-        echo "# deb     https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Netherlands" >> ${target}
-        echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Russia" >> ${target}
-        echo "# deb     https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# Sweden" >> ${target}
-        echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# United States" >> ${target}
-        echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# Austria" >> ${target}
+	echo "# deb     https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Belgium" >> ${target}
+	echo "# deb     https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Denmark" >> ${target}
+	echo "# deb     https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Ecuador" >> ${target}
+	echo "# deb     https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Germany" >> ${target}
+	echo "# deb     https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Hong Kong" >> ${target}
+	echo "# deb     https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Hungary" >> ${target}
+	echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Italy" >> ${target}
+	echo "# deb     https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Netherlands" >> ${target}
+	echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Russia" >> ${target}
+	echo "# deb     https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# Sweden" >> ${target}
+	echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# United States" >> ${target}
+	echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
 
 	target="/etc/apt/sources.list.d/fixes.list"
-        echo "# This is the default mirror, choosen at first boot." > ${target}
-        echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
+	echo "# This is the default mirror, choosen at first boot." > ${target}
+	echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
 	echo "deb      ${FLL_MIRROR}fixes unstable main non-free-firmware" >> ${target}
 	echo "#deb-src ${FLL_MIRROR}fixes unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-        echo "# austria" >> ${target}
-        echo "# deb     https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# belgium" >> ${target}
-        echo "# deb     https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# denmark" >> ${target}
-        echo "# deb     https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# ecuador" >> ${target}
-        echo "# deb     https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# germany" >> ${target}
-      	echo "# deb     https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# hong kong" >> ${target}
-        echo "# deb     https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# hungary" >> ${target}
-        echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# italy" >> ${target}
-        echo "# deb     https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# netherlands" >> ${target}
-        echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# russia" >> ${target}
-        echo "# deb     https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# sweden" >> ${target}
-        echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# united states" >> ${target}
-        echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "" >> ${target}
-        echo "# deb     https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-        echo "# deb-src https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# austria" >> ${target}
+	echo "# deb     https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# belgium" >> ${target}
+	echo "# deb     https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# denmark" >> ${target}
+	echo "# deb     https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# ecuador" >> ${target}
+	echo "# deb     https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# germany" >> ${target}
+	echo "# deb     https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# hong kong" >> ${target}
+	echo "# deb     https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# hungary" >> ${target}
+	echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# italy" >> ${target}
+	echo "# deb     https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# netherlands" >> ${target}
+	echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# russia" >> ${target}
+	echo "# deb     https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# sweden" >> ${target}
+	echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# united states" >> ${target}
+	echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "" >> ${target}
+	echo "# deb     https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
+	echo "# deb-src https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
 
 
 	target="/etc/apt/sources.list.d/dbgsym.list"

--- a/share/fll-live-initscripts/fll_locales
+++ b/share/fll-live-initscripts/fll_locales
@@ -309,7 +309,7 @@ apt_install_lang() {
 		return
 	fi
 
-	LIVEAPT="${FLL_MOUNTPOINT}.2/i18n"
+	LIVEAPT="${FLL_MOUNTPOINT}./i18n"
 	if [ ! -d "${LIVEAPT}" ]; then
 		return
 	fi
@@ -400,229 +400,213 @@ apt_install_lang_clean() {
 	rm -rf ${LIVEAPTSOURCES}
 }
 
-localize_sources_list() {
-# deploy load balancing for siduction mirrors
-# atm we these usable mirrors:
-#   1) ftp.gwdg.de
-#   2) siduction.office-vienna.at
-#   3) ftp.uni-stuttgart.de
-#   4) packages.siduction.site
-# REPOS:
-#   3) extra
-#   4) fixes        - provided directly via packages.siduction.site
+write_deb822() {
+# Preparation an entry for the .sources files.
+enable=$6
+for typ in $(echo "$2"); do
+	if [ "X$typ" == "Xdeb-src" ]; then
+		enable="no"
+		echo "" >> $1
+	fi
+	
+cat << EOF >> $1
+	Types:      $typ
+	URIs:       $3
+	Suites:     $4
+	Components: $5
+	Enabled:    $enable
+	Signed-By:  $7
+EOF	
+done
+}
 
-	case "$(mawk 'BEGIN{print int(9 * rand())}')" in
-		0)
-		 # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
-		 FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
-		 ;;
-		1)
-		 # OfficeVienna EDV-Dienstleistungen und IT-Consulting, Austria
-		 FLL_MIRROR="https://siduction.office-vienna.at/"
-		 ;;
-		2)
-		 #
-		 ;;
-		3)
-		 # Gesellschaft für wissenschaftliche Datenverarbeitung mbH Göttingen, Germany
-		 FLL_MIRROR="https://ftp.gwdg.de/pub/linux/siduction/"
-		 ;;
-		4)
-		 # University Stuttgart, Germany
-		 FLL_MIRROR="https://ftp.uni-stuttgart.de/siduction/"
-		 ;;
-		5)
-		 # BelNet, Belgium
-		 FLL_MIRROR="https://ftp.belnet.be/mirror/siduction/"
-		 ;;
-		6)
-		 # Studenten Net Twente, Netherlands
-		 FLL_MIRROR="https://ftp.snt.utwente.nl/pub/linux/siduction/"
-		 ;;
-		7)
-		 # Consortium GARR, Italy
-		 FLL_MIRROR="https://siduction.mirror.garr.it/"
-		 ;;
-		*)
-		 # siduction main mirror, with TLS since Sunday, 21/08/2016
-		 FLL_MIRROR="https://packages.siduction.org/"
-		 ;;
+localize_sources() {
+	# Deploy load balancing for siduction mirrors.
+	# Assign mirror URLs to states and state groups.
+	# Select the mirror that matches the country code.
+	# Mirrors available in: AT BE DE DK EC HK HU IT NL RU SE US
+
+	full_list=(Austria Belgium Denmark Ecuador Germany Hong_Kong Hungary Italy \
+			Netherlands Russia Sweden United_States)
+
+	# LOCALE GROUPS                                             # MIRROR POOL
+	#-----------------------------------------------------------#------------
+	# america_north: AG CA US MX                                # US
+	# america_south: BO BR CL CO CR EC GT NI PA PE PR SV UY VE  # EC
+	# asia:          CN HK IN JP KR PH SG TW                    # HK
+	# europe_east:   BY CY HR PL RO UA TR                       # HU RU
+	# europe_north:  EE FI IE IS NO                             # DK SE
+	# europe_south:  BA BG GR SI                                # IT
+	# europe_center_west and all those not listed:              # AT DE BE NL
+
+	# Arrays containing the URLs.
+	Austria=(\
+		https://siduction.office-vienna.at/)
+	Belgium=(\
+		https://ftp.belnet.be/mirror/siduction/)
+	Denmark=(\
+		https://mirrors.dotsrc.org/siduction/)
+	Ecuador=(\
+		https://mirror.cedia.org.ec/siduction/)
+	Germany=(\
+		https://packages.siduction.org/ \
+		https://ftp.gwdg.de/pub/linux/siduction/ \
+		https://ftp.halifax.rwth-aachen.de/siduction/ \
+		https://ftp.spline.de/pub/siduction/ \
+		https://ftp.uni-stuttgart.de/siduction/)
+	Hong_Kong=(\
+		https://mirror-hk.koddos.net/siduction/)
+	Hungary=(\
+		https://quantum-mirror.hu/mirrors/pub/siduction/)
+	Italy=(\
+		https://siduction.mirror.garr.it/)
+	Netherlands=(\
+		https://ftp.snt.utwente.nl/pub/linux/siduction/)
+	Russia=(\
+		https://mirror.yandex.ru/mirrors/siduction/)
+	Sweden=(\
+		https://ftp.acc.umu.se/mirror/siduction.org/)
+	United_States=(\
+		http://ftp.gtlib.gatech.edu/pub/siduction/ \
+		https://mirror.math.princeton.edu/pub/siduction/ \
+		https://liquorix.net/siduction/)
+
+	# Selecting the mirror according to the locale.
+	case $DEMO_CODE in 
+		AT)
+		mirror=(${Austria[@]})
+		;;
+		BE)
+		mirror=(${Belgium[@]})
+		;;
+		DE)
+		mirror=(${Germany[@]})
+		;;
+		DK)
+		mirror=(${Denmark[@]})
+		;;
+		HU)
+		mirror=(${Hungary[@]})
+		;;
+		NL)
+		mirror=(${Netherlands[@]})
+		;;
+		RU)
+		mirror=(${Russia[@]})
+		;;
+		SE)
+		mirror=(${Sweden[@]})
+		;;
+		AG|CA|US|MX) # america_north
+		mirror=(${United_States[@]})
+		;;
+		BO|BR|CL|CO|CR|EC|GT|NI|PA|PE|PR|SV|UY|VE) # america_south
+		mirror=(${Ecuador[@]})
+		;;
+		CN|HK|IN|JP|KR|PH|SG|TW) # asia
+		mirror=(${Hong_Kong[@]})
+		;;
+		BY|CY|HR|PL|RO|UA|TR) # europe_east
+		mirror=(${Hungary[@]} ${Russia[@]})
+		;;
+		EE|FI|IE|IS|NO) # europe_north
+		mirror=(${Denmark[@]} ${Sweden[@]})
+		;;
+		BA|BG|GR|IT|SI) # europe_south
+		mirror=(${Italy[@]})
+		;;
+		*) # europe_center_west
+		mirror=(${Austria[@]} ${Germany[@]} ${Belgium[@]} ${Netherlands[@]})
+		;;
 	esac
 
-	target="/etc/apt/sources.list.d/debian.list"
+	# Load balancing with multiple mirrors.
+	nr=${#mirror[@]}
+	NR="$(mawk 'BEGIN{print int('"$nr"' * rand())}')"
+	FLL_MIRROR=${mirror[NR]}
+	## FEHLERTEST einbauen
+	# if -z $FLL_MIRROR
+
+
+	# debian.sources
+	target="/etc/apt/sources.list.d/debian.sources"
+	url="https://deb.debian.org/debian/"
+	compo="main non-free-firmware"
+	key="/usr/share/keyrings/debian-archive-keyring.gpg"
+
 	echo "# debian loadbalancer" > ${target}
-	echo "deb      https://deb.debian.org/debian/ unstable main non-free-firmware" >> ${target}
-	echo "#deb-src https://deb.debian.org/debian/ unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-	echo "# deb     https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
-	echo "# deb-src https://deb.debian.org/debian/ experimental main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb      https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
-	echo "# deb-src  https://incoming.debian.org/debian-buildd buildd-unstable main non-free-firmware" >> ${target}
+	write_deb822 "${target}" "deb deb-src" "$url" "unstable" "$compo" "yes" "$key"
 
-	target="/etc/apt/sources.list.d/extra.list"
-	echo "# This is the default mirror, choosen at first boot." > ${target}
-	echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
-	echo "deb      ${FLL_MIRROR}extra unstable main non-free-firmware" >> ${target}
-	echo "#deb-src ${FLL_MIRROR}extra unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-	echo "# Austria" >> ${target}
-	echo "# deb     https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://siduction.office-vienna.at/extra unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-	echo "# Belgium" >> ${target}
-	echo "# deb     https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.belnet.be/mirror/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Denmark" >> ${target}
-	echo "# deb     https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirrors.dotsrc.org/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Ecuador" >> ${target}
-	echo "# deb     https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.cedia.org.ec/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Germany" >> ${target}
-	echo "# deb     https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://packages.siduction.org/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.spline.de/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.uni-stuttgart.de/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Hong Kong" >> ${target}
-	echo "# deb     https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror-hk.koddos.net/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Hungary" >> ${target}
-	echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Italy" >> ${target}
-	echo "# deb     https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://siduction.mirror.garr.it/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Netherlands" >> ${target}
-	echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Russia" >> ${target}
-	echo "# deb     https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# Sweden" >> ${target}
-	echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# United States" >> ${target}
-	echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://liquorix.net/siduction/extra unstable main non-free-firmware" >> ${target}
+	write_deb822 "${target}" "deb deb-src" "$url" "experimental" "$compo" "no" "$key"
 
-	target="/etc/apt/sources.list.d/fixes.list"
-	echo "# This is the default mirror, choosen at first boot." > ${target}
-	echo "# One might consider to choose the geographical nearest or the fastest mirror." >> ${target}
-	echo "deb      ${FLL_MIRROR}fixes unstable main non-free-firmware" >> ${target}
-	echo "#deb-src ${FLL_MIRROR}fixes unstable main non-free-firmware" >> ${target}
+	url="https://incoming.debian.org/debian-buildd"
 	echo "" >> ${target}
-	echo "# austria" >> ${target}
-	echo "# deb     https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://siduction.office-vienna.at/fixes unstable main non-free-firmware" >> ${target}
 	echo "" >> ${target}
-	echo "# belgium" >> ${target}
-	echo "# deb     https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.belnet.be/mirror/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# denmark" >> ${target}
-	echo "# deb     https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirrors.dotsrc.org/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# ecuador" >> ${target}
-	echo "# deb     https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.cedia.org.ec/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# germany" >> ${target}
-	echo "# deb     https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://packages.siduction.org/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.gwdg.de/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.halifax.rwth-aachen.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.spline.de/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.uni-stuttgart.de/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# hong kong" >> ${target}
-	echo "# deb     https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror-hk.koddos.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# hungary" >> ${target}
-	echo "# deb     https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://quantum-mirror.hu/mirrors/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# italy" >> ${target}
-	echo "# deb     https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://siduction.mirror.garr.it/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://mirror.lug.udel.edu/pub/siduction/extra unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# netherlands" >> ${target}
-	echo "# deb     https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.snt.utwente.nl/pub/linux/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# russia" >> ${target}
-	echo "# deb     https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.yandex.ru/mirrors/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# sweden" >> ${target}
-	echo "# deb     https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://ftp.acc.umu.se/mirror/siduction.org/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# united states" >> ${target}
-	echo "# deb     http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src http://ftp.gtlib.gatech.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://mirror.math.princeton.edu/pub/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "" >> ${target}
-	echo "# deb     https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
-	echo "# deb-src https://liquorix.net/siduction/fixes unstable main non-free-firmware" >> ${target}
+	write_deb822 "${target}" "deb deb-src" "$url" "buildd-unstable" "$compo" "no" "$key"
 
 
-	target="/etc/apt/sources.list.d/dbgsym.list"
-	echo "# deb http://debug.mirrors.debian.org/debian-debug/ testing-debug main non-free-firmware" > ${target}
-	echo "# deb http://debug.mirrors.debian.org/debian-debug/ unstable-debug main non-free-firmware" >> ${target}
-	echo "# deb http://debug.mirrors.debian.org/debian-debug/ experimental-debug main non-free-firmware" >> ${target}
+	# debian debug.sources
+	target="/etc/apt/sources.list.d/dbgsym.sources"
+	url="https://debug.mirrors.debian.org/debian-debug"
+	compo="main contrib non-free-firmware"
+
+	echo "# debian debug" > ${target}
 	echo "" >> ${target}
+	write_deb822 "${target}" "deb" "$url" "testing-debug" "$compo" "no" "$key"
 
-	# we don't provide a i386 kernel anymore - we choose the fine liquorix kernel instead.
-	# so we should provide a upgrade path for this kernel
-	if $(uname -v | grep -q liquorix); then
-		target="/etc/apt/sources.list.d/liquorix.list"
-		echo "deb     https://liquorix.net/debian sid main" > ${target}
-		echo "deb-src https://liquorix.net/debian sid main" >> ${target}
-		echo "" >> ${target}
-	fi
+	echo "" >> ${target}
+	write_deb822 "${target}" "deb" "$url" "unstable-debug" "$compo" "no" "$key"
 
+	echo "" >> ${target}
+	write_deb822 "${target}" "deb" "$url" "experimental-debug" "$compo" "no" "$key"
+
+
+	# siduction extra.sources and fixes.sources
+	key="/usr/share/keyrings/siduction-archive-keyring.gpg"
+	compo="main non-free-firmware"
+
+	for target_file in "extra.sources" "fixes.sources"; do
+		target="/etc/apt/sources.list.d/$target_file"
+		
+cat << EOF > $target
+# This is the default mirror, choosen at first boot.
+# One might consider to choose the geographical nearest or the fastest mirror.
+
+EOF
+		
+		write_deb822 "${target}" "deb deb-src" "$FLL_MIRROR" "unstable" "$compo" "yes" "$key"
+		
+		for country in ${full_list[@]}; do
+			number=1
+			echo "" >> ${target}
+			echo "" >> ${target}
+			echo "$country:" >> ${target}
+			
+			# Set and use indirection to access array values.
+			choice=$country[@]
+			for url in ${!choice}; do
+				if [ $number -gt 1 ]; then
+					echo "" >> ${target}
+					echo "" >> ${target}
+				fi
+				write_deb822 "${target}" "deb deb-src" "$url" "unstable" "$compo" "no" "$key"
+				((++number))
+			done
+		done
+	done
+
+	## TO DO
+	#	# we don't provide a i386 kernel anymore - we choose the fine liquorix kernel instead.
+	#	# so we should provide a upgrade path for this kernel
+	#	if $(uname -v | grep -q liquorix); then
+	#		target="/etc/apt/sources.list.d/liquorix.list"
+	#		echo "deb     https://liquorix.net/debian sid main" > ${target}
+	#		echo "deb-src https://liquorix.net/debian sid main" >> ${target}
+	#		echo "" >> ${target}
+	#	fi
 }
 
 save_locale_variables() {
@@ -639,7 +623,7 @@ case "${1}" in
 		set_locale
 		set_console
 		apt_install_lang
-		localize_sources_list
+		localize_sources
 		save_locale_variables
 		;;
 	localize)
@@ -647,7 +631,7 @@ case "${1}" in
 		set_locale
 		set_console
 		apt_install_lang
-		localize_sources_list
+		localize_sources
 		save_locale_variables
 		;;
 	*)

--- a/share/fll-live-initscripts/fll_locales
+++ b/share/fll-live-initscripts/fll_locales
@@ -7,16 +7,17 @@
 ###
 # F.U.L.L.S.T.O.R.Y
 #
-# Copyright: (C) 2007 - 2008 Kel Modderman <kel@otaku42.de>
+# Copyright: (C) 2007 - 2024 Kel Modderman <kelvmod@gmail.com>
 #            (C) 2008 Michael Deelwater <michael.deelwater@googlemail.com>
 #            (C) 2016 Niall Walsh <niallwalsh@celtux.org>
+#            (C) 2017 - 2024 Stefan Lippers-Hollmann <s.l-h@gmx.de>
 # License:   GPLv2
 #
 # F.U.L.L.S.T.O.R.Y Project Homepage:
 # https://github.com/fullstory
 ###
 
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
+PATH=/usr/sbin:/usr/bin
 NAME="fll-locales"
 
 if [ "${1}" = "list" ]; then
@@ -63,7 +64,7 @@ FONTSIZE="16"
 ###
 # some keyboard-configuration defaults
 ###
-XKBMODEL="linux"
+XKBMODEL="pc105"
 XKBLAYOUT="us"
 XKBVARIANT=""
 XKBOPTIONS="lv3:ralt_switch,compose:lwin,grp:alt_shift_toggle"
@@ -267,7 +268,7 @@ set_locale()
 	###
 	# select default locale and configure console-data via debconf
 	###
-	echo "configuring locales for '${LANG}'"
+	echo "${NAME}: configuring locales for '${LANG}'"
 
 	echo "locales locales/default_environment_locale select ${LANG}" | \
 		debconf-set-selections
@@ -431,10 +432,10 @@ localize_sources_list() {
 	         # BelNet, Belgium
 	         FLL_MIRROR="https://ftp.belnet.be/mirror/siduction/"
 	         ;;
-        6)
-	         # Studenten Net Twente, Netherlands
-	         FLL_MIRROR="https://ftp.snt.utwente.nl/pub/linux/siduction/"
-	         ;;
+#        6)
+#	         # Studenten Net Twente, Netherlands
+#	         FLL_MIRROR="https://ftp.snt.utwente.nl/pub/linux/siduction/"
+#	         ;;
         7)
 	         # Consortium GARR, Italy
 	         FLL_MIRROR="https://siduction.mirror.garr.it/"

--- a/share/fll-live-initscripts/fll_locales
+++ b/share/fll-live-initscripts/fll_locales
@@ -402,22 +402,21 @@ apt_install_lang_clean() {
 
 write_deb822() {
 # Preparation an entry for the .sources files.
-enable=$6
-for typ in $(echo "$2"); do
-	if [ "X$typ" == "Xdeb-src" ]; then
-		enable="no"
-		echo "" >> $1
-	fi
+	for typ in $(echo "${types}"); do
+		if [ "X${typ}" == "Xdeb-src" ]; then
+			yes_no="no"
+			echo "" >> ${target}
+		fi
 	
-cat << EOF >> $1
-	Types:      $typ
-	URIs:       $3
-	Suites:     $4
-	Components: $5
-	Enabled:    $enable
-	Signed-By:  $7
-EOF	
-done
+	cat << EOF >> ${target}
+	Types:      ${typ}
+	URIs:       ${url}
+	Suites:     ${suites}
+	Components: ${compo}
+	Enabled:    ${yes_no}
+	Signed-By:  ${key}
+EOF
+	done
 }
 
 localize_sources() {
@@ -524,60 +523,70 @@ localize_sources() {
 	nr=${#mirror[@]}
 	NR="$(mawk 'BEGIN{print int('"$nr"' * rand())}')"
 	FLL_MIRROR=${mirror[NR]}
-	## FEHLERTEST einbauen
-	# if -z $FLL_MIRROR
-
 
 	# debian.sources
 	target="/etc/apt/sources.list.d/debian.sources"
+	types="deb deb-src"
 	url="https://deb.debian.org/debian/"
+	suites="unstable"
 	compo="main non-free-firmware"
+	yes_no="yes"
 	key="/usr/share/keyrings/debian-archive-keyring.gpg"
 
 	echo "# debian loadbalancer" > ${target}
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb deb-src" "$url" "unstable" "$compo" "yes" "$key"
+	write_deb822
 
+	suites="experimental"
+	yes_no="no"
 	echo "" >> ${target}
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb deb-src" "$url" "experimental" "$compo" "no" "$key"
+	write_deb822
 
 	url="https://incoming.debian.org/debian-buildd"
+	suites="buildd-unstable"
 	echo "" >> ${target}
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb deb-src" "$url" "buildd-unstable" "$compo" "no" "$key"
+	write_deb822
 
 
 	# debian debug.sources
 	target="/etc/apt/sources.list.d/dbgsym.sources"
+	types="deb"
 	url="https://debug.mirrors.debian.org/debian-debug"
+	suites="testing-debug"
 	compo="main contrib non-free-firmware"
-
 	echo "# debian debug" > ${target}
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb" "$url" "testing-debug" "$compo" "no" "$key"
+	write_deb822
 
+	suites="unstable-debug"
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb" "$url" "unstable-debug" "$compo" "no" "$key"
+	write_deb822
 
+	suites="experimental-debug"
 	echo "" >> ${target}
-	write_deb822 "${target}" "deb" "$url" "experimental-debug" "$compo" "no" "$key"
+	write_deb822
 
 
 	# siduction extra.sources and fixes.sources
-	key="/usr/share/keyrings/siduction-archive-keyring.gpg"
+	types="deb deb-src"
+	suites="unstable"
 	compo="main non-free-firmware"
+	key="/usr/share/keyrings/siduction-archive-keyring.gpg"
 
 	for target_file in "extra.sources" "fixes.sources"; do
 		target="/etc/apt/sources.list.d/$target_file"
+		url="${FLL_MIRROR}"
+		yes_no="yes"
 		
-cat << EOF > $target
+		cat << EOF > $target
 # This is the default mirror, choosen at first boot.
 # One might consider to choose the geographical nearest or the fastest mirror.
 
 EOF
 		
-		write_deb822 "${target}" "deb deb-src" "$FLL_MIRROR" "unstable" "$compo" "yes" "$key"
+		write_deb822
 		
 		for country in ${full_list[@]}; do
 			number=1
@@ -592,21 +601,25 @@ EOF
 					echo "" >> ${target}
 					echo "" >> ${target}
 				fi
-				write_deb822 "${target}" "deb deb-src" "$url" "unstable" "$compo" "no" "$key"
+				write_deb822
 				((++number))
 			done
 		done
 	done
 
-	## TO DO
-	#	# we don't provide a i386 kernel anymore - we choose the fine liquorix kernel instead.
-	#	# so we should provide a upgrade path for this kernel
-	#	if $(uname -v | grep -q liquorix); then
-	#		target="/etc/apt/sources.list.d/liquorix.list"
-	#		echo "deb     https://liquorix.net/debian sid main" > ${target}
-	#		echo "deb-src https://liquorix.net/debian sid main" >> ${target}
-	#		echo "" >> ${target}
-	#	fi
+	# we don't provide a i386 kernel anymore -
+	# we choose the fine liquorix kernel instead.
+	# so we should provide a upgrade path for this kernel
+	target="/etc/apt/sources.list.d/liquorix.sources"
+	url="https://liquorix.net/debian"
+	suites="sid"
+	compo="main"
+	yes_no="no"
+	key="/usr/share/keyrings/liquorix-keyring.gpg"
+
+	echo "# liquorix kernel" > ${target}
+	echo "" >> ${target}
+	write_deb822
 }
 
 save_locale_variables() {

--- a/share/fll-live-initscripts/locales.csv
+++ b/share/fll-live-initscripts/locales.csv
@@ -1,94 +1,94 @@
-locale	default	model	layout	variant	options	tz	locales	notes
-00_00.utf8	0		us			Etc/UTC	en_US.utf8	
-be_BY.utf8	0		by,us			Europe/Minsk	en_US.utf8	
-bg_BG.utf8	0		bg,us			Europe/Sofia	en_US.utf8	
-bs_BA.utf8	0		ba,us			Europe/Sarajevo	en_US.utf8	
-C	0		us			Etc/UTC	en_US.utf8	
-cs_CZ.utf8	0		cz,us			Europe/Prague	en_US.utf8	
-da_DK.utf8	0		dk,us			Europe/Copenhagen	en_US.utf8	
-de_AT.utf8			de,us			Europe/Vienna	de_DE.utf8 en_US.utf8	
-de_BE.utf8			be,de,fr,us			Europe/Brussels	de_DE.utf8 fr_FR.utf8 en_US.utf8	whats sensible?
-de_CH.utf8			ch,us	fr		Europe/Zurich	de_DE.utf8 en_US.utf8	is the fr variant sane?
-de_DE.utf8	0		de,us			Europe/Berlin	US.utf8
-de_LI.utf8			de,us			Europe/Vaduz	de_DE.utf8 en_US.utf8	
-de_LU.utf8			de,us			Europe/Luxembourg	de_DE.utf8 en_US.utf8	
-el_CY.utf8			gr,us			Europe/Athens	en_US.utf8	
-el_GR.utf8	0		gr,us			Europe/Athens	en_US.utf8	
-en_AG.utf8			us			America/Antigua	en_US.utf8	
-en_AU.utf8			us			Australia/Sydney	en_US.utf8	
-en_BW.utf8			us			Africa/Gaborone	en_US.utf8	
-en_CA.utf8			us,ca			America/Toronto	en_US.utf8	
-en_DK.utf8			dk,us			Europe/Copenhagen	en_US.utf8	
-en_GB.utf8			gb,us			Europe/London	en_US.utf8	
-en_HK.utf8			us			Asia/Hong_Kong	en_US.utf8	
-en_IE.utf8			ie,gb,us			Europe/Dublin	en_GB.utf8 en_US.utf8	
-en_IN.utf8			us			Asia/Kolkata	en_US.utf8	
-en_NG.utf8			us			Africa/Lagos	en_US.utf8	
-en_NZ.utf8			us			Pacific/Auckland	en_US.utf8	
-en_PH.utf8			us			Asia/Manila	en_US.utf8	
-en_SG.utf8			us			Asia/Singapore	en_US.utf8	
-en_US.utf8	0		us			US/NewYork	C	
-en_ZA.utf8			us			Africa/Johannesburg	en_US.utf8	
-en_ZW.utf8			us			Africa/Harare	en_US.utf8	
-es_AR.utf8			latam,es,us			America/Argentina/Buenos_Aires	es_ES.utf8 en_US.utf8	
-es_BO.utf8			latam,es,us			America/La_Paz	es_ES.utf8 en_US.utf8	
-es_CL.utf8			latam,es,us			America/Santiago	es_ES.utf8 en_US.utf8	
-es_CO.utf8			latam,es,us			America/Bogota	es_ES.utf8 en_US.utf8	
-es_CR.utf8			latam,es,us			America/Costa_Rica	es_ES.utf8 en_US.utf8	
-es_DO.utf8			latam,es,us			America/Santo_Domingo	es_ES.utf8 en_US.utf8	
-es_EC.utf8			latam,es,us			America/Guayaquil	es_ES.utf8 en_US.utf8	
-es_ES.utf8	0		es,us			Europe/Madrid	en_US.utf8	 (old comment?)
-es_GT.utf8			latam,es,us			America/Guatemala	es_ES.utf8 en_US.utf8	
-es_HN.utf8			latam,es,us			America/Tegucigalpa	es_ES.utf8 en_US.utf8	
-es_MX.utf8			latam,es,us			America/Mexico_City	es_ES.utf8 en_US.utf8	
-es_NI.utf8			latam,es,us			America/Managua	es_ES.utf8 en_US.utf8	
-es_PA.utf8			latam,es,us			America/Panama	es_ES.utf8 en_US.utf8	
-es_PE.utf8			latam,es,us			America/Lima	es_ES.utf8 en_US.utf8	
-es_PR.utf8			latam,es,us			America/Puerto_Rico	es_ES.utf8 en_US.utf8	
-es_PY.utf8			latam,es,us			America/Asuncion	es_ES.utf8 en_US.utf8	
-es_SV.utf8			latam,es,us			America/El_Salvador	es_ES.utf8 en_US.utf8	
-es_US.utf8			latam,es,us			America/New_York	es_ES.utf8 en_US.utf8	
-es_UY.utf8			latam,es,us			America/Montevideo	es_ES.utf8 en_US.utf8	
-es_VE.utf8			latam,es,us			America/Caracas	es_ES.utf8 en_US.utf8	
-et_EE.utf8	0		et,us			Europe/Tallinn	en_US.utf8	
-fi_FI.utf8	0		fi,us			Europe/Helsinki	en_US.utf8	
-fr_BE.utf8			be,fr,us			Europe/Brussels	fr_FR.utf8 en_US.utf8	should this be fr first?
-fr_CA.utf8			ca,us			America/Toronto	fr_FR.utf8 en_US.utf8	should this offer fr keyboards? Fallback to nl before en?
-fr_CH.utf8			ch,us	fr		Europe/Zurich	en_US.utf8	
-fr_FR.utf8	0		fr,us			Europe/Paris	en_US.utf8	
-fr_LU.utf8			fr,us			Europe/Luxembourg	fr_FR.utf8 en_US.utf8	
-fr_NC.utf8			fr,us			Pacific/Noumea	fr_FR.utf8 en_US.utf8	not a real locale
-ga_IE.utf8	0		ie,gb,us			Europe/Dublin	en_IE.utf8 en_GB.utf8 en_US.utf8	
-he_IL.utf8	0		il,us			Asia/Jerusalem	en_US.utf8	, must be saner then us?
-hr_HR.utf8	0		hr,us			Europe/Zagreb	en_US.utf8	
-hu_HU.utf8	0		hu,us			Europe/Budapest	en_US.utf8	
-is_IS.utf8	0		is,us			Atlantic/Reykjavik	en_US.utf8
-it_CH.utf8			it,de,fr,us			Europe/Zurich	it_IT.utf8 en_US.utf8	
-it_IT.utf8	0		it,us			Europe/Rome	en_US.utf8	
-ja_JP.utf8	0		jp,us			Asia/Tokyo	en_US.utf8	
-ko_KR.utf8	0		kr,us			Asia/Seoul	en_US.utf8	
-nb_NO.utf8	0		no,us			Europe/Oslo	nb_NO.utf8 en_US.utf8	
-nl_AW.utf8			us,nl			America/Aruba	nl_NL.utf8 en_US.utf8	us seems “sane”
-nl_BE.utf8			be,fr,us			Europe/Brussels	nl_NL.utf8 en_US.utf8
-nl_NL.utf8	0		us,nl			Europe/Amsterdam	en_US.utf8	
-nn_NO.utf8	0		no,us			Europe/Oslo	nn_NO.utf8 en_US.utf8	
-pl_PL.utf8	0		pl,us			Europe/Warsaw	en_US.utf8	
-pt_BR.utf8	0		br,us			America/Sao_Paulo	pt_PT.utf8 en_US.utf8	
-pt_PT.utf8			pt,us			Europe/Lisbon	pt_BR.utf8 en_US.utf8	
-ro_RO.utf8	0		ro,us			Europe/Bucharest	en_US.utf8	
-ru_RU.utf8	0		ru,us			Europe/Moscow	en_US.utf8	
-ru_UA.utf8			ru,us			Europe/Kiev	en_US.utf8	
-se_FI.utf8			fi,no,se,us	fi		Europe/Helsinki	fi_FI.utf8 en_US.utf8	
-se_NO.utf8			no,fi,se,us	smi		Europe/Oslo	nn_NO.utf8 en_US.utf8	
-se_SE.utf8	0		se,fi,no,us	smi		Europe/Stockholm	sv_SE.utf8 en_US.utf8
-sk_SK.utf8	0		sk,us			Europe/Bratislava	en_US.utf8	
-sl_SI.utf8	0		si,us			Europe/Ljubljana	en_US.utf8	#CONSOLEFONT=iso02g
-sv_FI.utf8			se,fi,us	basic		Europe/Helsinki	en_US.utf8	
-sv_SE.utf8	0		se,us	basic		Europe/Stockholm	en_US.utf8	not built
-tr_CY.utf8			tr,us			Europe/Istanbul	en_US.utf8	
-tr_TR.utf8	0		tr,us			Europe/Istanbul	en_US.utf8	
-uk_UA.utf8	0		ua,ru,us			Europe/Kiev	en_US.utf8
-zh_CN.utf8	0		us			Asia/Shaghai	zh_TW en_US.utf8	
-zh_HK.utf8			us			Asia/Hong_Kong	zh_CH en_US.utf8	
-zh_SG.utf8			us			Asia/Singapore	zh_CH en_US.utf8	
-zh_TW.utf8			us			Asia/Taipei	zh_CN en_US.utf8	
+locale	default	layout	variant	locales
+00_00.utf8	0	us		en_US.utf8
+be_BY.utf8	0	by,us		en_US.utf8
+bg_BG.utf8	0	bg,us		en_US.utf8
+bs_BA.utf8	0	ba,us		en_US.utf8
+C	0	us		en_US.utf8
+cs_CZ.utf8	0	cz,us		en_US.utf8
+da_DK.utf8	0	dk,us		en_US.utf8
+de_AT.utf8	1	de,us		de_DE.utf8 en_US.utf8
+de_BE.utf8	1	be,de,fr,us		de_DE.utf8 fr_FR.utf8 en_US.utf8
+de_CH.utf8	1	ch,us	fr	de_DE.utf8 en_US.utf8
+de_DE.utf8	0	de,us		de_DE.utf8 en_US.utf8
+de_LI.utf8	1	de,us		de_DE.utf8 en_US.utf8
+de_LU.utf8	1	de,us		de_DE.utf8 en_US.utf8
+el_CY.utf8	1	gr,us		en_US.utf8
+el_GR.utf8	0	gr,us		en_US.utf8
+en_AG.utf8	1	us		en_US.utf8
+en_AU.utf8	1	us		en_US.utf8
+en_BW.utf8	1	us		en_US.utf8
+en_CA.utf8	1	us,ca		en_US.utf8
+en_DK.utf8	1	dk,us		en_US.utf8
+en_GB.utf8	1	gb,us		en_US.utf8
+en_HK.utf8	1	us		en_US.utf8
+en_IE.utf8	1	ie,gb,us		en_GB.utf8 en_US.utf8
+en_IN.utf8	1	us		en_US.utf8
+en_NG.utf8	1	us		en_US.utf8
+en_NZ.utf8	1	us		en_US.utf8
+en_PH.utf8	1	us		en_US.utf8
+en_SG.utf8	1	us		en_US.utf8
+en_US.utf8	0	us		en_US.utf8
+en_ZA.utf8	1	us		en_US.utf8
+en_ZW.utf8	1	us		en_US.utf8
+es_AR.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_BO.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_CL.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_CO.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_CR.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_DO.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_EC.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_ES.utf8	0	es,us		en_US.utf8
+es_GT.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_HN.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_MX.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_NI.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_PA.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_PE.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_PR.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_PY.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_SV.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_US.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_UY.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+es_VE.utf8	1	latam,es,us		es_ES.utf8 en_US.utf8
+et_EE.utf8	0	et,us		en_US.utf8
+fi_FI.utf8	0	fi,us		en_US.utf8
+fr_BE.utf8	1	be,fr,us		fr_FR.utf8 en_US.utf8
+fr_CA.utf8	1	ca,us		fr_FR.utf8 en_US.utf8
+fr_CH.utf8	1	ch,us	fr	en_US.utf8
+fr_FR.utf8	0	fr,us		en_US.utf8
+fr_LU.utf8	1	fr,us		fr_FR.utf8 en_US.utf8
+fr_NC.utf8	1	fr,us		fr_FR.utf8 en_US.utf8
+ga_IE.utf8	0	ie,gb,us		en_IE.utf8 en_GB.utf8 en_US.utf8
+he_IL.utf8	0	il,us		en_US.utf8
+hr_HR.utf8	0	hr,us		en_US.utf8
+hu_HU.utf8	0	hu,us		en_US.utf8
+is_IS.utf8	0	is,us		en_US.utf8
+it_CH.utf8	1	it,de,fr,us		it_IT.utf8 en_US.utf8
+it_IT.utf8	0	it,us		en_US.utf8
+ja_JP.utf8	0	jp,us		en_US.utf8
+ko_KR.utf8	0	kr,us		en_US.utf8
+nb_NO.utf8	0	no,us		nb_NO.utf8 en_US.utf8
+nl_AW.utf8	1	us,nl		nl_NL.utf8 en_US.utf8
+nl_BE.utf8	1	be,fr,us		nl_NL.utf8 en_US.utf8
+nl_NL.utf8	0	us,nl		en_US.utf8
+nn_NO.utf8	0	no,us		nn_NO.utf8 en_US.utf8
+pl_PL.utf8	0	pl,us		en_US.utf8
+pt_BR.utf8	0	br,us		pt_PT.utf8 en_US.utf8
+pt_PT.utf8	1	pt,us		pt_BR.utf8 en_US.utf8
+ro_RO.utf8	0	ro,us		en_US.utf8
+ru_RU.utf8	0	ru,us		en_US.utf8
+ru_UA.utf8	1	ru,us		en_US.utf8
+se_FI.utf8	1	fi,no,se,us	fi	fi_FI.utf8 en_US.utf8
+se_NO.utf8	1	no,fi,se,us	smi	nn_NO.utf8 en_US.utf8
+se_SE.utf8	0	se,fi,no,us	smi	sv_SE.utf8 en_US.utf8
+sk_SK.utf8	0	sk,us		en_US.utf8
+sl_SI.utf8	0	si,us		en_US.utf8
+sv_FI.utf8	1	se,fi,us	basic	en_US.utf8
+sv_SE.utf8	0	se,us	basic	en_US.utf8
+tr_CY.utf8	1	tr,us		en_US.utf8
+tr_TR.utf8	0	tr,us		en_US.utf8
+uk_UA.utf8	0	ua,ru,us		en_US.utf8
+zh_CN.utf8	0	us		zh_TW en_US.utf8
+zh_HK.utf8	1	us		zh_CH en_US.utf8
+zh_SG.utf8	1	us		zh_CH en_US.utf8
+zh_TW.utf8	1	us		zh_CN en_US.utf8


### PR DESCRIPTION
Commit vom 4. August:
Teilweise Aktualisierung von /github.com/fullstory/fll-live-initscripts

Commit vom 10. August:
Änderung der sources Dateien für /etc/apt/sources.list.d/ auf das deb822 Format.

Die Änderungen haben bei mir in einem separaten Skript das gewünschte Format für alle vier Dateien erzeugt.
Ich benötige für Testzwecke ein ISO, dass speziell mit den Dateien **locales.csv** und **fll_locales** gebaut wurde.
